### PR TITLE
docs: Mention `pgx_json_schema` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ for more complete installation guidelines see the [pgx](https://github.com/tcdi/
 ## Prior Art
 
 [postgres-json-schema](https://github.com/gavinwahl/postgres-json-schema) - an implementation of JSON Schema for Postgres written in PL/pgSQL
+[pgx_json_schema](https://github.com/jefbarn/pgx_json_schema) - an implementation of JSON Schema for Postgres written with pgx
 
 
 ## Benchmark


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update to the `Prior Art` section. As that extension is based on `pgx` as well, it feels that it should be mentioned in that section.

## What is the current behavior?

...

## What is the new behavior?

...

## Additional context

Thank you for using my crate here :)
