### PR TITLE
Fix: gh actions to support pg15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Install Postgres
     - name: install postgres
-      run: sudo apt-get install -y clang-10 llvm-10 clang gcc make build-essential libz-dev zlib1g-dev strace libssl-dev pkg-config postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
+      run: sudo apt-get install -y clang-11 llvm-11 clang gcc make build-essential libz-dev zlib1g-dev strace libssl-dev pkg-config postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
 
     # update cargo indexes so we're sure we get the latest things from 'git' repo dependencies
     - name: cargo update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "=0.6.0-alpha.0"
+pgx = "=0.6.0-alpha.1"
 serde = "1.0"
 serde_json = "1.0"
 jsonschema = {version = "0.16.0", default-features = false, features = []}
 
 [dev-dependencies]
-pgx-tests = "=0.6.0-alpha.0"
+pgx-tests = "=0.6.0-alpha.1"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,17 @@ default = ["pg13"]
 pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
 pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
 pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
+pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "~0.5.6"
+pgx = "=0.6.0-alpha.0"
 serde = "1.0"
 serde_json = "1.0"
 jsonschema = {version = "0.16.0", default-features = false, features = []}
 
 [dev-dependencies]
-pgx-tests = "0.5.6"
+pgx-tests = "=0.6.0-alpha.0"
 
 [profile.dev]
 panic = "unwind"


### PR DESCRIPTION
## What kind of change does this PR introduce?

It looks like clang10 and llvm10 support for pg15 has been removed, or is it still a bug, to solve this workflow problem I did some tests with versions 11 and it worked, I didn't want to open a new PR as it still seems to be within the scope of this one .

## What is the current behavior?

Can check https://www.postgresql.org/message-id/16858-5d0e07f17734b197%40postgresql.org
