### PR TITLE
Allow installation from non-root users

### DIFF
--- a/pg_jsonschema.control
+++ b/pg_jsonschema.control
@@ -2,4 +2,4 @@ comment = 'pg_jsonschema'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_jsonschema'
 relocatable = false
-superuser = false
+superuser = true


### PR DESCRIPTION
## What kind of change does this PR introduce?

At this moment, it's impossible to install this extension under non-privileged user because "C" language is untrusted. 

## What is the current behavior?

```
create extension pg_jsonschema;

ERROR: permission denied for language c (SQLSTATE 42501)
```

## What is the new behavior?

```
create extension pg_jsonschema;
CREATE EXTENSION
```

## Additional context

Changes at `pgx` template

tcdi/pgx#1056

