### PR TITLE
upgrade to latest pgrx (v0.8.4)

### DIFF
--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -10,6 +10,6 @@ services:
       USER: postgres
     command:
       - cargo
-      - pgx
+      - pgrx
       - test
       - pg14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           - pg_jsonschema
         package_name:
           - pg-jsonschema
-        pgx_version:
+        pgrx_version:
           - 0.7.1
         postgres: [14, 15]
         box:
@@ -75,12 +75,12 @@ jobs:
           # Ensure cargo/rust on path
           source "$HOME/.cargo/env"
 
-          cargo install cargo-pgx --version ${{ matrix.pgx_version }} --locked
-          cargo pgx init --pg${{ matrix.postgres }}=/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config
+          cargo install cargo-pgrx --version ${{ matrix.pgrx_version }} --locked
+          cargo pgrx init --pg${{ matrix.postgres }}=/usr/lib/postgresql/${{ matrix.postgres }}/bin/pg_config
 
           # selects the pgVer from pg_config on path
-          # https://github.com/tcdi/pgx/issues/288
-          cargo pgx package --no-default-features --features pg${{ matrix.postgres }}
+          # https://github.com/tcdi/pgrx/issues/288
+          cargo pgrx package --no-default-features --features pg${{ matrix.postgres }}
 
           # Create installable package
           mkdir archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         package_name:
           - pg-jsonschema
         pgrx_version:
-          - 0.7.1
+          - 0.8.4
         postgres: [14, 15]
         box:
           - { runner: ubuntu-20.04, arch: amd64 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,20 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["pg15"]
-pg12 = ["pgx/pg12", "pgx-tests/pg12" ]
-pg13 = ["pgx/pg13", "pgx-tests/pg13" ]
-pg14 = ["pgx/pg14", "pgx-tests/pg14" ]
-pg15 = ["pgx/pg15", "pgx-tests/pg15" ]
+pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgx = "0.7.1"
+pgrx = "0.8.4"
 serde = "1.0"
 serde_json = "1.0"
 jsonschema = {version = "0.16.0", default-features = false, features = []}
 
 [dev-dependencies]
-pgx-tests = "0.7.1"
+pgrx-tests = "0.8.4"
 
 [profile.dev]
 panic = "unwind"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ for more complete installation guidelines see the [pgrx](https://github.com/tcdi
 
 [is_jsonb_valid](https://github.com/furstenheim/is_jsonb_valid) - JSON Schema Postgres extension written in C
 
-[pgrx_json_schema](https://github.com/jefbarn/pgrx_json_schema) - JSON Schema Postgres extension written with pgrx + jsonschema
+[pgx_json_schema](https://github.com/jefbarn/pgx_json_schema) - JSON Schema Postgres extension written with pgrx + jsonschema
 
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ Spin up Postgres with pg_jsonschema installed in a docker container via `docker-
 
 
 Requires:
-- [pgx](https://github.com/tcdi/pgx)
+- [pgrx](https://github.com/tcdi/pgrx)
 
 
 ```shell
-cargo pgx run
+cargo pgrx run
 ```
 
 which drops into a psql prompt.
@@ -110,7 +110,7 @@ pg_jsonschema=# select json_matches_schema('{"type": "object"}', '{}');
 (1 row)
 ```
 
-for more complete installation guidelines see the [pgx](https://github.com/tcdi/pgx) docs.
+for more complete installation guidelines see the [pgrx](https://github.com/tcdi/pgrx) docs.
 
 
 ## Prior Art
@@ -119,7 +119,7 @@ for more complete installation guidelines see the [pgx](https://github.com/tcdi/
 
 [is_jsonb_valid](https://github.com/furstenheim/is_jsonb_valid) - JSON Schema Postgres extension written in C
 
-[pgx_json_schema](https://github.com/jefbarn/pgx_json_schema) - JSON Schema Postgres extension written with pgx + jsonschema
+[pgrx_json_schema](https://github.com/jefbarn/pgrx_json_schema) - JSON Schema Postgres extension written with pgrx + jsonschema
 
 
 ## Benchmark

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -27,7 +27,7 @@ RUN \
   cargo --version
 
 # PGX
-RUN cargo install cargo-pgrx --version 0.7.1 --locked
+RUN cargo install cargo-pgrx --version 0.8.4 --locked
 
 RUN cargo pgrx init --pg14 $(which pg_config)
 

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -27,14 +27,14 @@ RUN \
   cargo --version
 
 # PGX
-RUN cargo install cargo-pgx --version 0.7.1 --locked
+RUN cargo install cargo-pgrx --version 0.7.1 --locked
 
-RUN cargo pgx init --pg14 $(which pg_config)
+RUN cargo pgrx init --pg14 $(which pg_config)
 
 USER root
 
 COPY . .
-RUN cargo pgx install
+RUN cargo pgrx install
 
 RUN chown -R postgres:postgres /home/supa
 RUN chown -R postgres:postgres /usr/share/postgresql/14/extension

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use pgx::*;
+use pgrx::*;
 
 pg_module_magic!();
 
@@ -15,7 +15,7 @@ fn jsonb_matches_schema(schema: Json, instance: JsonB) -> bool {
 #[pg_schema]
 #[cfg(any(test, feature = "pg_test"))]
 mod tests {
-    use pgx::*;
+    use pgrx::*;
     use serde_json::json;
 
     #[pg_test]


### PR DESCRIPTION
We had a question on our Discord about `pg_jsonschema` not being on the latest pgrx. Now it is!

Edit:  Tests pass locally.

```
running 8 tests
    Building extension with features pg_test pg15
     Running command "/home/zombodb/.rustup/toolchains/1.67.1-x86_64-unknown-linux-gnu/bin/cargo" "build" "--features" "pg_test pg15" "--no-default-features" "--message-format=json-render-diagnostics"
  Installing extension
     Copying control file to /home/zombodb/.pgrx/15.3/pgrx-install/share/postgresql/extension/pg_jsonschema.control
     Copying shared library to /home/zombodb/.pgrx/15.3/pgrx-install/lib/postgresql/pg_jsonschema.so
    Finished installing pg_jsonschema
The files belonging to this database system will be owned by user "zombodb".
This user must also own the server process.

The database cluster will be initialized with locale "C.UTF-8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

creating directory /home/zombodb/_work/pg_jsonschema/target/pgrx-test-data-15 ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting default time zone ... America/New_York
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    /home/zombodb/.pgrx/15.3/pgrx-install/bin/pg_ctl -D /home/zombodb/_work/pg_jsonschema/target/pgrx-test-data-15 -l logfile start

test tests::pg_test_json_not_matches_schema_rs ... ok
test tests::pg_test_jsonb_not_matches_schema_spi ... ok
test tests::pg_test_jsonb_not_matches_schema_rs ... ok
test tests::pg_test_json_matches_schema_rs ... ok
test tests::pg_test_jsonb_matches_schema_rs ... ok
test tests::pg_test_json_matches_schema_spi ... ok
test tests::pg_test_jsonb_matches_schema_spi ... ok
test tests::pg_test_json_not_matches_schema_spi ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 48.10s

```