### PR TITLE
Upgrade to pgrx 0.9.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         package_name:
           - pg-jsonschema
         pgrx_version:
-          - 0.8.4
+          - 0.9.7
         postgres: [14, 15]
         box:
           - { runner: ubuntu-20.04, arch: amd64 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "0.8.4"
+pgrx = "0.9.7"
 serde = "1.0"
 serde_json = "1.0"
 jsonschema = {version = "0.16.0", default-features = false, features = []}
 
 [dev-dependencies]
-pgrx-tests = "0.8.4"
+pgrx-tests = "0.9.7"
 
 [profile.dev]
 panic = "unwind"

--- a/dockerfiles/db/Dockerfile
+++ b/dockerfiles/db/Dockerfile
@@ -27,7 +27,7 @@ RUN \
   cargo --version
 
 # PGX
-RUN cargo install cargo-pgrx --version 0.8.4 --locked
+RUN cargo install cargo-pgrx --version 0.9.7 --locked
 
 RUN cargo pgrx init --pg14 $(which pg_config)
 


### PR DESCRIPTION
A critical bug concerning handling arrays with an initial null element was discovered in pgrx versions 0.8.0 to 0.9.6, recommending an upgrade to 0.9.7 as soon as is possible.

Also fixes https://github.com/supabase/pg_jsonschema/issues/30