### PR TITLE
feat: add the validate utils

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ fn validate_json_schema(schema: Json, instance: Json) -> bool {
 }
 
 #[pg_extern(immutable, strict)]
-fn validate_jsonb_schema(schema: Json, instance: JsonB) -> Result<(), Vec<String>> {
+fn validate_jsonb_schema(schema: Json, instance: JsonB) -> bool {
     let compiled = match jsonschema::JSONSchema::compile(&schema.0) {
         Ok(c) => c,
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,90 @@ mod tests {
             "type": "obj"
         }))));
     }
+
+    #[pg_test]
+    fn test_json_validates_schema_rs() {
+        let max_length: i32 = 5;
+        assert!(crate::validate_json_schema(
+            Json(json!({ "maxLength": max_length })),
+            Json(json!("foo")),
+        ));
+    }
+
+    #[pg_test]
+    fn test_json_not_validates_schema_rs() {
+        let max_length: i32 = 5;
+        assert!(!crate::validate_json_schema(
+            Json(json!({ "maxLength": max_length })),
+            Json(json!("foobar")),
+        ));
+    }
+
+    #[pg_test]
+    fn test_jsonb_validates_schema_rs() {
+        let max_length: i32 = 5;
+        assert!(crate::validate_jsonb_schema(
+            Json(json!({ "maxLength": max_length })),
+            JsonB(json!("foo")),
+        ));
+    }
+
+    #[pg_test]
+    fn test_jsonb_not_validates_schema_rs() {
+        let max_length: i32 = 5;
+        assert!(!crate::validate_jsonb_schema(
+            Json(json!({ "maxLength": max_length })),
+            JsonB(json!("foobar")),
+        ));
+    }
+
+    #[pg_test]
+    fn test_json_validates_schema_spi() {
+        let result = Spi::get_one::<bool>(
+            r#"
+            select validate_json_schema('{"type": "object"}', '{}')
+        "#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(result);
+    }
+
+    #[pg_test]
+    fn test_json_not_validates_schema_spi() {
+        let result = Spi::get_one::<bool>(
+            r#"
+            select validate_json_schema('{"type": "object"}', '1')
+        "#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!result);
+    }
+
+    #[pg_test]
+    fn test_jsonb_validates_schema_spi() {
+        let result = Spi::get_one::<bool>(
+            r#"
+            select validate_jsonb_schema('{"type": "object"}', '{}')
+        "#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(result);
+    }
+
+    #[pg_test]
+    fn test_jsonb_not_validates_schema_spi() {
+        let result = Spi::get_one::<bool>(
+            r#"
+            select validate_jsonb_schema('{"type": "object"}', '1')
+        "#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!result);
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,16 +182,15 @@ mod tests {
                         "type": "boolean"
                     },
                     "additionalProperties": false,
-                    "required": ["foo", "bar", "baz"]
                 }
             })),
-            Json(json!({"foo": 1, "bar": [], "bat": true})),
+            Json(json!({"foo": 1, "bar": [], "baz": "1"})),
         );
-        assert!(errors.len() == 1);
-        assert!(
-            errors[0]
-                == "[\"foo\",\"bar\",\"baz\"] is not of types \"boolean\", \"object\"".to_string()
-        );
+
+        assert!(errors.len() == 3);
+        assert!(errors[0] == "[] is not of type \"number\"".to_string());
+        assert!(errors[1] == "\"1\" is not of type \"boolean\"".to_string());
+        assert!(errors[2] == "1 is not of type \"string\"".to_string());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,20 +7,9 @@ fn json_matches_schema(schema: Json, instance: Json) -> bool {
     if jsonschema::is_valid(&schema.0, &instance.0) {
         true
     } else {
-        let compiled = match jsonschema::JSONSchema::compile(&schema.0) {
-            Ok(c) => c,
-            Err(e) => {
-                // Only call notice! for a non empty instance_path
-                if e.instance_path.last().is_some() {
-                    notice!(
-                        "Invalid JSON schema at path: {}",
-                        e.instance_path.to_string()
-                    );
-                }
-                return false;
-            }
-        };
-
+        // "jsonschema::is_valid(...)" already checks the validaity of JSON schema, and panics if it is invalid.
+        // Hence, we just unwrap the schema here.
+        let compiled = jsonschema::JSONSchema::compile(&schema.0).unwrap();
         let err = compiled.validate(&instance.0).unwrap_err();
         let _ = err
             .into_iter()
@@ -35,20 +24,9 @@ fn jsonb_matches_schema(schema: Json, instance: JsonB) -> bool {
     if jsonschema::is_valid(&schema.0, &instance.0) {
         true
     } else {
-        let compiled = match jsonschema::JSONSchema::compile(&schema.0) {
-            Ok(c) => c,
-            Err(e) => {
-                // Only call notice! for a non empty instance_path
-                if e.instance_path.last().is_some() {
-                    notice!(
-                        "Invalid JSON schema at path: {}",
-                        e.instance_path.to_string()
-                    );
-                }
-                return false;
-            }
-        };
-
+        // "jsonschema::is_valid(...)" already checks the validaity of JSON schema, and panics if it is invalid.
+        // Hence, we just unwrap the schema here.
+        let compiled = jsonschema::JSONSchema::compile(&schema.0).unwrap();
         let err = compiled.validate(&instance.0).unwrap_err();
         let _ = err
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ fn json_matches_schema(schema: Json, instance: Json) -> bool {
     if jsonschema::is_valid(&schema.0, &instance.0) {
         true
     } else {
-        // "jsonschema::is_valid(...)" already checks the validaity of JSON schema, and panics if it is invalid.
+        // "jsonschema::is_valid(...)" already checks the validity of JSON schema, and panics if it is invalid.
         // Hence, we just unwrap the schema here.
         let compiled = jsonschema::JSONSchema::compile(&schema.0).unwrap();
         let err = compiled.validate(&instance.0).unwrap_err();
@@ -24,7 +24,7 @@ fn jsonb_matches_schema(schema: Json, instance: JsonB) -> bool {
     if jsonschema::is_valid(&schema.0, &instance.0) {
         true
     } else {
-        // "jsonschema::is_valid(...)" already checks the validaity of JSON schema, and panics if it is invalid.
+        // "jsonschema::is_valid(...)" already checks the validity of JSON schema, and panics if it is invalid.
         // Hence, we just unwrap the schema here.
         let compiled = jsonschema::JSONSchema::compile(&schema.0).unwrap();
         let err = compiled.validate(&instance.0).unwrap_err();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,30 @@ fn jsonb_matches_schema(schema: Json, instance: JsonB) -> bool {
     jsonschema::is_valid(&schema.0, &instance.0)
 }
 
+#[pg_extern(immutable, strict)]
+fn validate_json_schema(schema: Json, instance: Json) -> Result<(), Vec<String>> {
+    let compiled = match jsonschema::JSONSchema::compile(&schema.0) {
+        Ok(c) => c,
+        Err(e) => Err(vec![e.to_string()]),
+    };
+    match compiled.validate(&instance.0) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.into_iter().map(String::from).collect::<String>()),
+    }
+}
+
+#[pg_extern(immutable, strict)]
+fn validate_jsonb_schema(schema: Json, instance: JsonB) -> Result<(), Vec<String>> {
+    let compiled = match jsonschema::JSONSchema::compile(&schema.0) {
+        Ok(c) => c,
+        Err(e) => Err(vec![e.to_string()]),
+    };
+    match compiled.validate(&instance.0) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.into_iter().map(String::from).collect::<String>()),
+    }
+}
+
 #[pg_schema]
 #[cfg(any(test, feature = "pg_test"))]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,19 +41,21 @@ fn validate_json_schema(schema: Json, instance: Json) -> bool {
                     e.instance_path.to_string()
                 );
             }
-            false
+            return false;
         }
     };
-    match compiled.validate(&instance.0) {
+
+    let is_valid = match compiled.validate(&instance.0) {
         Ok(_) => true,
         Err(e) => {
             let _ = e
                 .into_iter()
-                .map(|e| notice!("Invalid instance {} at {}", e.instance, e.instance_path))
-                .collect();
+                .for_each(|e| notice!("Invalid instance {} at {}", e.instance, e.instance_path));
             false
         }
-    }
+    };
+
+    is_valid
 }
 
 #[pg_extern(immutable, strict)]
@@ -68,19 +70,21 @@ fn validate_jsonb_schema(schema: Json, instance: JsonB) -> bool {
                     e.instance_path.to_string()
                 );
             }
-            false
+            return false;
         }
     };
-    match compiled.validate(&instance.0) {
+
+    let is_valid = match compiled.validate(&instance.0) {
         Ok(_) => true,
         Err(e) => {
             let _ = e
                 .into_iter()
-                .map(|e| notice!("Invalid instance {} at {}", e.instance, e.instance_path))
-                .collect();
+                .for_each(|e| notice!("Invalid instance {} at {}", e.instance, e.instance_path));
             false
         }
-    }
+    };
+
+    is_valid
 }
 
 #[pg_schema]


### PR DESCRIPTION
## What kind of change does this PR introduce?
Add the `validate` utils for getting the actual validation errors thrown while validating the json schema and instance.

## What is the current behavior?
Solves #14 

## What is the new behavior?
Receives the actual errors thrown, as `Vec<String>`

## Additional context

