### PR TITLE
fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ create extension pg_jsonschema;
 
 create table customer(
     id serial primary key,
-    ...
     metadata json,
 
     check (


### PR DESCRIPTION
This PR removes the redundant ellipsis in the example which creates the `customer` table. The ellipsis doesn't any any value but rather detracts the user from trying out the extension for the first time because they can't just copy and paste the example.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
