### PR TITLE
add jsonschema_is_valid function and its tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,25 @@
 
 
 ## API
-Two SQL functions:
+Three SQL functions:
 - json_matches_schema
 - jsonb_matches_schema (note the **jsonb** in front)
+- jsonschema_is_valid
 
 With the following signatures
 ```sql
 -- Validates a json *instance* against a *schema*
 json_matches_schema(schema json, instance json) returns bool
 ```
-and 
+and
 ```sql
 -- Validates a jsonb *instance* against a *schema*
 jsonb_matches_schema(schema json, instance jsonb) returns bool
+```
+and
+```sql
+-- Validates whether a json *schema* is valid
+jsonschema_is_valid(schema json) returns bool
 ```
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,13 @@ fn jsonschema_is_valid(schema: Json) -> bool {
     match jsonschema::JSONSchema::compile(&schema.0) {
         Ok(_) => true,
         Err(e) => {
-            notice!(
-                "Invalid JSON schema at path: {}",
-                e.instance_path.to_string()
-            );
+            // Only call notice! for a non empty instance_path
+            if e.instance_path.last().is_some() {
+                notice!(
+                    "Invalid JSON schema at path: {}",
+                    e.instance_path.to_string()
+                );
+            }
             false
         }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Fixes #28 

## What is the new behavior?

This PR adds a function `jsonschema_is_valid(schema: Json)` which returns true/false if the schema is valid/invalid. If the schema is invalid it also raises a notice which tells the user which part of the schema is invalid. For example when a valid schema is provided it return true:

```
pg_jsonschema=# select jsonschema_is_valid('{"type": "object", "properties": { "tags": { "type": "array", "items": { "type": "string", "maxLength": 16 } } } }');
 jsonschema_is_valid
---------------------
 t
(1 row)
````

And when an invalid schema is provided (notice typo `sting` instead of `string` in input schema):

```
pg_jsonschema=# select jsonschema_is_valid('{"type": "object", "properties": { "tags": { "type": "array", "items": { "type": "sting", "maxLength": 16 } } } }');
NOTICE:  Invalid JSON schema at path: /properties/tags/items
 jsonschema_is_valid
---------------------
 f
(1 row)
```

## Additional context


