### PR TITLE
Fix README benchmark typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ select
         'b', i::text
     )
 from
-    generate_series(1, 200000) t(i);
+    generate_series(1, 20000) t(i);
 -- Query Completed in 2.18 seconds 
 ```
 for comparison, the equivalent test using postgres-json-schema's `validate_json_schema` function ran in 5.54 seconds. pg_jsonschema's ~2.5x speedup on this example JSON schema grows quickly as the schema becomes more complex.


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update, ...

Conflicting info in readme, in one place it says 20k while in the code snippet it's 200000. Upon testing on an M1 Pro machine it 20k is more realistic