### PR TITLE
Delete `::jsonb` of Supabase SQL script in README because cause an error on Supabase SQL Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ create table customer(
                         }
                     }
                 }
-            }'::json,
+            }',
             metadata
         )
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improve documentation

## What is the current behavior?

```sh
ERROR:  42883: function extensions.jsonb_matches_schema(jsonb, jsonb) does not exist

HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

<img width="738" alt="imatge" src="https://github.com/user-attachments/assets/0b592eaf-39d7-4d85-8679-9035f3bee82f">

## What is the new behavior?

Supabase SQL Editor works with the extension function.

