### PR TITLE
chore: update jsonschema to 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pg_test = []
 pgrx = "0.12.6"
 serde = "1.0"
 serde_json = "1.0"
-jsonschema = {version = "0.17.1", default-features = false, features = []}
+jsonschema = {version = "0.28.0", default-features = false}
 
 [dev-dependencies]
 pgrx-tests = "0.12.6"


### PR DESCRIPTION
This PR updates `jsonschema` to `0.28.0` and makes use of its newer APIs.
