### PR TITLE
chore: bump ubuntu image to ubuntu-latest in GH actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   code-coverage:
     name: Code Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: Release
 
-
 on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 permissions:
   contents: write # Required to upload release assets
@@ -46,7 +45,7 @@ jobs:
           - 0.12.9
         postgres: [14, 15, 16, 17]
         box:
-          - { runner: ubuntu-20.04, arch: amd64 }
+          - { runner: ubuntu-latest, arch: amd64 }
           - { runner: arm-runner, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90


### PR DESCRIPTION
`ubuntu-20.04` are deprecated on GH, bumped images to `ubuntu-latest`.