### PR TITLE
use GitHub public arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         postgres: [14, 15, 16, 17, 18]
         box:
           - { runner: ubuntu-latest, arch: amd64 }
-          - { runner: arm-runner, arch: arm64 }
+          - { runner: ubuntu-24.04-arm, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build: use GitHub public arm64 runner

## What is the current behavior?

arm64 builds in forks stuck waiting to build

## What is the new behavior?

arm64 builds in forks complete

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
