### PR TITLE
feat: Compiled JSON Schema type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.37.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae66e2951b8570591298ab528f9f457bcc38cdc24ee927cece9310248aa32a74"
+checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
 dependencies = [
  "ahash",
  "bytecount",
@@ -878,6 +878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +898,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "minimal-lexical"
@@ -1100,6 +1112,7 @@ name = "pg_jsonschema"
 version = "0.3.4"
 dependencies = [
  "jsonschema",
+ "lru",
  "pgrx",
  "pgrx-tests",
  "serde",
@@ -1451,14 +1464,16 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.37.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1efd6958dfa348f532982eaa367ffbf78e077bc8f1f7a0173778914ec647437"
+checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
 dependencies = [
  "ahash",
  "fluent-uri",
  "getrandom",
  "hashbrown 0.16.0",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ pg_test = []
 pgrx = "0.16.1"
 serde = "1.0"
 serde_json = "1.0"
-jsonschema = { version = "0.37.1", default-features = false, features = [
+jsonschema = { version = "0.46.0", default-features = false, features = [
     "arbitrary-precision",
 ] }
+lru = { version = "0.16", default-features = false }
 
 [dev-dependencies]
 pgrx-tests = "0.16.1"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ and
 jsonschema_validation_errors(schema json, instance json) returns text[]
 ```
 
+### Compiled schema type
+
+For repeated validation against the same schema, cast it to `jsonschema` once. The validator is compiled and cached per callsite, avoiding recompilation on every row.
+
+```sql
+-- Validates a json instance against a pre-compiled schema
+json_matches_compiled_schema(schema jsonschema, instance json) returns bool
+
+-- Validates a jsonb instance against a pre-compiled schema
+jsonb_matches_compiled_schema(schema jsonschema, instance jsonb) returns bool
+
+-- Returns validation errors for a json instance
+jsonschema_validation_errors_compiled(schema jsonschema, instance json) returns text[]
+
+-- Returns validation errors for a jsonb instance
+jsonb_validation_errors_compiled(schema jsonschema, instance jsonb) returns text[]
+```
+
 ## Usage
 
 Those functions can be used to constrain `json` and `jsonb` columns to conform to a schema.
@@ -192,9 +210,9 @@ The release process is composed of smaller scripts that can also be run independ
 
 #### System
 
-- 2021 MacBook Pro M1 Max (32GB)
-- macOS 14.2
-- PostgreSQL 16.2
+- 2024 MacBook Pro M4 Max (64GB)
+- macOS 26.3.1
+- PostgreSQL 16.13
 
 ### Setup
 
@@ -229,7 +247,18 @@ select
     )
 from
     generate_series(1, 20000) t(i);
--- Query Completed in 351 ms
+-- Query Completed in 195 ms
 ```
 
-for comparison, the equivalent test using postgres-json-schema's `validate_json_schema` function ran in 5.54 seconds. pg_jsonschema's ~15x speedup on this example JSON schema grows quickly as the schema becomes more complex.
+for comparison, the equivalent test using postgres-json-schema's `validate_json_schema` function ran in 2.0 seconds. pg_jsonschema's ~10x speedup on this example JSON schema grows quickly as the schema becomes more complex.
+
+### Compiled schema type
+
+Using the same schema and 20k inserts:
+
+| Method | 20k inserts |
+| ------ | ----------- |
+| `jsonb_matches_schema` — recompiles every row | ~195 ms |
+| `jsonb_matches_compiled_schema` — compiled once, cached | ~110 ms |
+
+~1.8x speedup; the gain grows with schema complexity since compilation cost is paid only once per callsite.

--- a/src/compiled/cache.rs
+++ b/src/compiled/cache.rs
@@ -1,0 +1,30 @@
+/// Backend-local LRU cache mapping canonical schema strings to compiled validators.
+///
+/// PostgreSQL backends are single-threaded OS processes, so a `thread_local`
+/// `RefCell` is sufficient — no mutex needed.
+use std::cell::RefCell;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+type Cache = lru::LruCache<String, Arc<jsonschema::Validator>>;
+
+const CAPACITY: NonZeroUsize = NonZeroUsize::new(128).expect("128 is non zero");
+
+thread_local! {
+    static CACHE: RefCell<Cache> = RefCell::new(lru::LruCache::new(CAPACITY));
+}
+
+/// Returns the cached validator for `schema`, inserting one produced by `f` on a miss.
+pub(super) fn get_or_insert(
+    schema: &str,
+    f: impl FnOnce() -> Arc<jsonschema::Validator>,
+) -> Arc<jsonschema::Validator> {
+    CACHE.with_borrow_mut(|c| {
+        if let Some(v) = c.get(schema) {
+            return Arc::clone(v);
+        }
+        let validator = f();
+        c.put(schema.to_owned(), Arc::clone(&validator));
+        validator
+    })
+}

--- a/src/compiled/callsite.rs
+++ b/src/compiled/callsite.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+
+use pgrx::*;
+
+use super::{JsonSchema, cache, compile_from_str};
+
+fn get_or_compile(schema: &JsonSchema) -> Arc<jsonschema::Validator> {
+    cache::get_or_insert(&schema.value, || compile_from_str(&schema.value))
+}
+
+/// Per-callsite validator cache in `fcinfo->flinfo->fn_extra`.
+struct FnExtraCache {
+    schema: String,
+    validator: Arc<jsonschema::Validator>,
+    info: *mut pg_sys::FmgrInfo,
+    stable_schema_arg: bool,
+    /// MemoryContextCallback; fires `drop_fn_extra_cache` when fn_mcxt is reset.
+    callback: pg_sys::MemoryContextCallback,
+}
+
+unsafe extern "C-unwind" fn drop_fn_extra_cache(arg: *mut std::ffi::c_void) {
+    // PG calls callbacks before freeing memory, so `entry` and `(*entry).flinfo` are
+    // still valid. Null fn_extra first so any re-entrant drop sees a clean slate.
+    unsafe {
+        let entry = arg as *mut FnExtraCache;
+        (*(*entry).info).fn_extra = std::ptr::null_mut();
+        std::ptr::drop_in_place(entry);
+    }
+}
+
+/// Returns a compiled validator for `schema`, using a two-level cache.
+///
+/// **L1** — per-callsite slot in `fcinfo->flinfo->fn_extra` (lifetime: `fn_mcxt`).
+/// When the schema argument is stable (immutable expression), the slot is reused
+/// unconditionally; otherwise it is reused on a string match.
+///
+/// **L2** — backend-local LRU (see [`super::cache`]).  Hit on L1 miss.
+///
+/// # Why two levels?
+///
+/// The L2 LRU lookup hashes the full canonical schema string on every call.
+/// For small schemas this is negligible, but large schemas make it expensive:
+/// a 3.3 MB FHIR schema hashed across 20k rows takes ~13 s via LRU alone vs
+/// ~1.8 s with the L1 callsite cache, which reduces each hot-path lookup to a
+/// pointer dereference.
+///
+/// # Safety
+/// `fcinfo` must be a valid, non-null `FunctionCallInfo` for the current call.
+pub(crate) unsafe fn fn_extra_get_or_compile(
+    schema: &JsonSchema,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Arc<jsonschema::Validator> {
+    unsafe {
+        let flinfo = (*fcinfo).flinfo;
+        let cached_ptr = if !(*flinfo).fn_extra.is_null() {
+            Some((*flinfo).fn_extra as *mut FnExtraCache)
+        } else {
+            None
+        };
+
+        // L1 hit: schema matches (or arg is stable, so it can't change).
+        if let Some(cached) = cached_ptr.map(|ptr| &*ptr)
+            && (cached.stable_schema_arg || cached.schema.as_str() == schema.value.as_str())
+        {
+            return Arc::clone(&cached.validator);
+        }
+
+        // L1 miss: pay the stability check once, then refresh or allocate.
+        let stable_schema_arg = pg_sys::get_fn_expr_arg_stable(flinfo, 0);
+
+        // Cache miss: refresh the callsite entry.
+        if let Some(cached_ptr) = cached_ptr {
+            let cached = &mut *cached_ptr;
+            let validator = get_or_compile(schema);
+            let cached_ptr = cached as *mut FnExtraCache;
+            let next = cached.callback.next;
+            let old_entry = std::mem::replace(
+                cached,
+                FnExtraCache {
+                    schema: schema.value.clone(),
+                    validator: Arc::clone(&validator),
+                    info: flinfo,
+                    stable_schema_arg,
+                    callback: pg_sys::MemoryContextCallback {
+                        func: Some(drop_fn_extra_cache),
+                        arg: cached_ptr as *mut std::ffi::c_void,
+                        next,
+                    },
+                },
+            );
+            drop(old_entry);
+            return validator;
+        }
+
+        // Cold path: allocate in fn_mcxt.
+        let validator = get_or_compile(schema);
+        let fn_mcxt = (*flinfo).fn_mcxt;
+        let old_mcxt = pg_sys::MemoryContextSwitchTo(fn_mcxt);
+
+        let cache_ptr = pg_sys::palloc(std::mem::size_of::<FnExtraCache>()) as *mut FnExtraCache;
+        std::ptr::write(
+            cache_ptr,
+            FnExtraCache {
+                schema: schema.value.clone(),
+                validator: Arc::clone(&validator),
+                info: flinfo,
+                stable_schema_arg,
+                callback: pg_sys::MemoryContextCallback {
+                    func: Some(drop_fn_extra_cache),
+                    arg: cache_ptr as *mut std::ffi::c_void,
+                    next: std::ptr::null_mut(),
+                },
+            },
+        );
+        pg_sys::MemoryContextRegisterResetCallback(
+            fn_mcxt,
+            std::ptr::addr_of_mut!((*cache_ptr).callback),
+        );
+        pg_sys::MemoryContextSwitchTo(old_mcxt);
+        (*flinfo).fn_extra = cache_ptr as *mut std::ffi::c_void;
+
+        validator
+    }
+}

--- a/src/compiled/callsite.rs
+++ b/src/compiled/callsite.rs
@@ -111,12 +111,12 @@ pub(crate) unsafe fn fn_extra_get_or_compile(
                 },
             },
         );
+        (*flinfo).fn_extra = cache_ptr as *mut std::ffi::c_void;
         pg_sys::MemoryContextRegisterResetCallback(
             fn_mcxt,
             std::ptr::addr_of_mut!((*cache_ptr).callback),
         );
         pg_sys::MemoryContextSwitchTo(old_mcxt);
-        (*flinfo).fn_extra = cache_ptr as *mut std::ffi::c_void;
 
         validator
     }

--- a/src/compiled/callsite.rs
+++ b/src/compiled/callsite.rs
@@ -72,7 +72,6 @@ pub(crate) unsafe fn fn_extra_get_or_compile(
         if let Some(cached_ptr) = cached_ptr {
             let cached = &mut *cached_ptr;
             let validator = get_or_compile(schema);
-            let cached_ptr = cached as *mut FnExtraCache;
             let next = cached.callback.next;
             let old_entry = std::mem::replace(
                 cached,

--- a/src/compiled/mod.rs
+++ b/src/compiled/mod.rs
@@ -1,0 +1,67 @@
+mod cache;
+mod callsite;
+
+use std::{ffi::CStr, sync::Arc};
+
+use pgrx::*;
+use serde_json::Value;
+
+pub(crate) use callsite::fn_extra_get_or_compile;
+
+/// JSON schema is stored as its canonical JSON string.
+///
+/// Canonicalization ensures semantically equivalent schemas share one string
+/// representation, maximising cache hits. The compiled [`jsonschema::Validator`]
+/// is held in a two-level cache: a per-callsite slot in `fn_extra`  and a
+/// bounded backend-local LRU.
+#[derive(
+    PostgresType,
+    PostgresEq,
+    PostgresHash,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[inoutfuncs]
+pub struct JsonSchema {
+    pub value: String,
+}
+
+impl JsonSchema {
+    /// Canonicalize, compile, and cache a JSON schema value.
+    pub(crate) fn compile(value: Value) -> Self {
+        let canonical = jsonschema::canonical::json::to_string(&value)
+            .unwrap_or_else(|err| pgrx::error!("failed to canonicalize JSON schema: {err}"));
+        cache::get_or_insert(&canonical, || compile_impl(&value, "invalid JSON schema"));
+        Self { value: canonical }
+    }
+}
+
+impl pgrx::inoutfuncs::InOutFuncs for JsonSchema {
+    fn input(input: &CStr) -> Self {
+        let value: Value = match serde_json::from_slice(input.to_bytes()) {
+            Ok(v) => v,
+            Err(err) => pgrx::error!("invalid JSON: {err}"),
+        };
+        Self::compile(value)
+    }
+
+    fn output(&self, buffer: &mut pgrx::StringInfo) {
+        buffer.push_str(&self.value);
+    }
+}
+
+fn compile_impl(value: &Value, error_prefix: &str) -> Arc<jsonschema::Validator> {
+    Arc::new(
+        jsonschema::validator_for(value)
+            .unwrap_or_else(|err| pgrx::error!("{error_prefix}: {err}")),
+    )
+}
+
+pub(super) fn compile_from_str(schema: &str) -> Arc<jsonschema::Validator> {
+    let value: Value = serde_json::from_str(schema)
+        .unwrap_or_else(|err| pgrx::error!("internal: failed to parse canonical schema: {err}"));
+    compile_impl(&value, "internal: failed to compile schema")
+}

--- a/src/compiled/mod.rs
+++ b/src/compiled/mod.rs
@@ -41,10 +41,8 @@ impl JsonSchema {
 
 impl pgrx::inoutfuncs::InOutFuncs for JsonSchema {
     fn input(input: &CStr) -> Self {
-        let value: Value = match serde_json::from_slice(input.to_bytes()) {
-            Ok(v) => v,
-            Err(err) => pgrx::error!("invalid JSON: {err}"),
-        };
+        let value: Value = serde_json::from_slice(input.to_bytes())
+            .unwrap_or_else(|err| pgrx::error!("invalid JSON: {err}"));
         Self::compile(value)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
+mod compiled;
+
 use pgrx::*;
+
+use compiled::{JsonSchema, fn_extra_get_or_compile};
 
 pg_module_magic!();
 
@@ -35,11 +39,363 @@ fn jsonschema_validation_errors(schema: Json, instance: Json) -> Vec<String> {
         .collect()
 }
 
+#[pg_extern(immutable, strict, parallel_safe)]
+fn jsonschema_from_json(schema: pgrx::Json) -> JsonSchema {
+    JsonSchema::compile(schema.0)
+}
+
+#[pg_extern(immutable, strict, parallel_safe)]
+fn jsonschema_from_jsonb(schema: pgrx::JsonB) -> JsonSchema {
+    JsonSchema::compile(schema.0)
+}
+
+pgrx::extension_sql!(
+    r#"
+    CREATE CAST (json AS jsonschema)
+        WITH FUNCTION jsonschema_from_json(json);
+
+    CREATE CAST (jsonb AS jsonschema)
+        WITH FUNCTION jsonschema_from_jsonb(jsonb);
+    "#,
+    name = "jsonschema_casts",
+    requires = [jsonschema_from_json, jsonschema_from_jsonb],
+);
+
+#[pg_extern(immutable, strict, parallel_safe)]
+fn json_matches_compiled_schema(
+    schema: JsonSchema,
+    instance: Json,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> bool {
+    let validator = unsafe { fn_extra_get_or_compile(&schema, fcinfo) };
+    validator.is_valid(&instance.0)
+}
+
+#[pg_extern(immutable, strict, parallel_safe)]
+fn jsonb_matches_compiled_schema(
+    schema: JsonSchema,
+    instance: pgrx::JsonB,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> bool {
+    let validator = unsafe { fn_extra_get_or_compile(&schema, fcinfo) };
+    validator.is_valid(&instance.0)
+}
+
+#[pg_extern(
+    immutable,
+    strict,
+    parallel_safe,
+    name = "jsonschema_validation_errors_compiled"
+)]
+fn jsonschema_validation_errors_compiled(
+    schema: JsonSchema,
+    instance: Json,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Vec<String> {
+    let validator = unsafe { fn_extra_get_or_compile(&schema, fcinfo) };
+    validator
+        .iter_errors(&instance.0)
+        .map(|err| err.to_string())
+        .collect()
+}
+
+#[pg_extern(
+    immutable,
+    strict,
+    parallel_safe,
+    name = "jsonb_validation_errors_compiled"
+)]
+fn jsonschema_validation_errors_compiled_jsonb(
+    schema: JsonSchema,
+    instance: pgrx::JsonB,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Vec<String> {
+    let validator = unsafe { fn_extra_get_or_compile(&schema, fcinfo) };
+    validator
+        .iter_errors(&instance.0)
+        .map(|err| err.to_string())
+        .collect()
+}
+
 #[pg_schema]
 #[cfg(any(test, feature = "pg_test"))]
 mod tests {
     use pgrx::*;
     use serde_json::json;
+
+    macro_rules! compiled_schema_tests {
+        (json { $($name:ident: $schema:literal, $instance:literal => $expected:literal)* }) => {$(
+            #[pg_test]
+            fn $name() {
+                let result = Spi::get_one::<bool>(concat!(
+                    "SELECT json_matches_compiled_schema('", $schema, "'::jsonschema, '", $instance, "'::json)"
+                )).unwrap().unwrap();
+                assert_eq!(result, $expected);
+            }
+        )*};
+        (jsonb { $($name:ident: $schema:literal, $instance:literal => $expected:literal)* }) => {$(
+            #[pg_test]
+            fn $name() {
+                let result = Spi::get_one::<bool>(concat!(
+                    "SELECT jsonb_matches_compiled_schema('", $schema, "'::jsonschema, '", $instance, "'::jsonb)"
+                )).unwrap().unwrap();
+                assert_eq!(result, $expected);
+            }
+        )*};
+        (errors_json { $($name:ident: $schema:literal, $instance:literal => [$($err:literal),*])* }) => {$(
+            #[pg_test]
+            fn $name() {
+                let errors = Spi::get_one::<Vec<String>>(concat!(
+                    "SELECT jsonschema_validation_errors_compiled('", $schema, "'::jsonschema, '",
+                    $instance, "'::json)"
+                )).unwrap().unwrap();
+                assert_eq!(errors, [$($err),*]);
+            }
+        )*};
+        (errors_jsonb { $($name:ident: $schema:literal, $instance:literal => [$($err:literal),*])* }) => {$(
+            #[pg_test]
+            fn $name() {
+                let errors = Spi::get_one::<Vec<String>>(concat!(
+                    "SELECT jsonb_validation_errors_compiled('", $schema, "'::jsonschema, '",
+                    $instance, "'::jsonb)"
+                )).unwrap().unwrap();
+                assert_eq!(errors, [$($err),*]);
+            }
+        )*};
+    }
+
+    compiled_schema_tests!(json {
+        test_json_matches_compiled_schema: r#"{"type":"string"}"#, r#""hello""# => true
+        test_json_rejects_compiled_schema: r#"{"type":"string"}"#, r#"42"#      => false
+    });
+
+    compiled_schema_tests!(jsonb {
+        test_jsonb_matches_compiled_schema: r#"{"type":"string"}"#, r#""hello""# => true
+        test_jsonb_rejects_compiled_schema: r#"{"type":"string"}"#, r#"42"#      => false
+    });
+
+    compiled_schema_tests!(errors_json {
+        test_validation_errors_compiled_with_error:
+            r#"{"maxLength":4}"#, r#""toolong""#
+            => [r#""toolong" is longer than 4 characters"#]
+    });
+
+    compiled_schema_tests!(errors_jsonb {
+        test_validation_errors_compiled_jsonb:
+            r#"{"type":"string"}"#, r#"42"#
+            => ["42 is not of type \"string\""]
+        test_validation_errors_compiled_jsonb_object:
+            r#"{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}"#,
+            r#"{"name":42}"#
+            => ["42 is not of type \"string\""]
+    });
+
+    #[pg_test]
+    fn test_jsonschema_cast_from_json() {
+        let result =
+            Spi::get_one::<bool>(r#"SELECT '{"type":"object"}'::json::jsonschema IS NOT NULL"#)
+                .unwrap()
+                .unwrap();
+        assert!(result);
+    }
+
+    #[pg_test]
+    fn test_jsonschema_cast_from_jsonb() {
+        let result =
+            Spi::get_one::<bool>(r#"SELECT '{"type":"object"}'::jsonb::jsonschema IS NOT NULL"#)
+                .unwrap()
+                .unwrap();
+        assert!(result);
+    }
+
+    #[pg_test]
+    fn test_jsonschema_output_is_canonical() {
+        let result = Spi::get_one::<String>(r#"SELECT '{"b":1,"a":2}'::jsonschema::text"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result, r#"{"a":2,"b":1}"#);
+    }
+
+    #[pg_test]
+    fn test_validation_errors_compiled_no_errors() {
+        let errors = Spi::get_one::<Vec<String>>(
+            r#"SELECT jsonschema_validation_errors_compiled('{"maxLength":4}'::jsonschema, '"foo"'::json)"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[pg_test]
+    fn test_validation_errors_compiled_multiple() {
+        let errors = Spi::get_one::<Vec<String>>(
+            r#"
+            SELECT jsonschema_validation_errors_compiled(
+                '{
+                    "type":"object",
+                    "properties":{
+                        "foo":{"type":"string"},
+                        "bar":{"type":"number"},
+                        "baz":{"type":"boolean"}
+                    }
+                }'::jsonschema,
+                '{"foo":1,"bar":[],"baz":"1"}'::json
+            )
+            "#,
+        )
+        .unwrap()
+        .unwrap();
+        let mut errors = errors;
+        errors.sort_unstable();
+        assert_eq!(
+            errors,
+            vec![
+                r#""1" is not of type "boolean""#.to_string(),
+                r#"1 is not of type "string""#.to_string(),
+                r#"[] is not of type "number""#.to_string(),
+            ]
+        );
+    }
+
+    #[pg_test]
+    fn test_compiled_schema_reuse_across_calls() {
+        let result = Spi::get_one::<i64>(
+            r#"
+            SELECT count(*)
+            FROM generate_series(1, 100) i
+            WHERE jsonb_matches_compiled_schema(
+                '{"type":"integer","minimum":0}'::jsonschema,
+                to_jsonb(i)
+            )
+        "#,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(result, 100);
+    }
+
+    #[pg_test]
+    fn test_canonical_dedup_same_validation() {
+        let r1 = Spi::get_one::<bool>(
+            r#"SELECT json_matches_compiled_schema('{"type":"string","maxLength":5}'::jsonschema, '"hi"'::json)"#,
+        )
+        .unwrap()
+        .unwrap();
+        let r2 = Spi::get_one::<bool>(
+            r#"SELECT json_matches_compiled_schema('{"maxLength":5,"type":"string"}'::jsonschema, '"hi"'::json)"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(r1);
+        assert!(r2);
+    }
+
+    #[pg_test]
+    fn test_callsite_cache_refresh_on_schema_change() {
+        // Two rows with different schemas at the same callsite.
+        // The second row triggers the L1 refresh path (fn_extra exists but schema changed).
+        let result = Spi::get_one::<i64>(
+            r#"
+            WITH data(s, v) AS (
+                VALUES
+                    ('{"type":"string"}'::jsonschema, '"hello"'::jsonb),
+                    ('{"type":"integer"}'::jsonschema, '42'::jsonb)
+            )
+            SELECT count(*) FROM data WHERE jsonb_matches_compiled_schema(s, v)
+            "#,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(result, 2);
+    }
+
+    #[pg_test]
+    fn test_check_constraint_with_compiled_schema() {
+        Spi::run(
+            r#"
+            CREATE TEMP TABLE test_compiled_check (
+                data jsonb,
+                CHECK (jsonb_matches_compiled_schema(
+                    '{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}'::jsonschema,
+                    data
+                ))
+            )
+        "#,
+        )
+        .unwrap();
+        Spi::run(r#"INSERT INTO test_compiled_check VALUES ('{"name":"alice"}')"#).unwrap();
+    }
+
+    #[pg_test]
+    fn test_jsonschema_roundtrip_in_column() {
+        Spi::run(
+            r#"
+            CREATE TEMP TABLE schema_store (id int, s jsonschema);
+            INSERT INTO schema_store VALUES
+                (1, '{"type":"string","maxLength":5}'::jsonschema),
+                (2, '{"type":"integer","minimum":0}'::jsonschema);
+        "#,
+        )
+        .unwrap();
+
+        let ok = Spi::get_one::<bool>(
+            r#"SELECT jsonb_matches_compiled_schema(s, '"hi"'::jsonb)
+               FROM schema_store WHERE id = 1"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(ok);
+
+        let not_ok = Spi::get_one::<bool>(
+            r#"SELECT jsonb_matches_compiled_schema(s, '"toolong"'::jsonb)
+               FROM schema_store WHERE id = 1"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!not_ok);
+
+        let ok_int = Spi::get_one::<bool>(
+            r#"SELECT jsonb_matches_compiled_schema(s, '42'::jsonb)
+               FROM schema_store WHERE id = 2"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(ok_int);
+
+        let not_ok_int = Spi::get_one::<bool>(
+            r#"SELECT jsonb_matches_compiled_schema(s, '-1'::jsonb)
+               FROM schema_store WHERE id = 2"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!not_ok_int);
+    }
+
+    #[pg_test]
+    fn test_jsonschema_equality() {
+        let result = Spi::get_one::<bool>(
+            r#"SELECT '{"type":"string","maxLength":5}'::jsonschema
+                    = '{"maxLength":5,"type":"string"}'::jsonschema"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(result, "canonically equal schemas must be SQL-equal");
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "invalid JSON: expected ident at line 1 column 2")]
+    fn test_invalid_json_cast_to_jsonschema() {
+        Spi::run("SELECT 'not valid json'::jsonschema").unwrap();
+    }
+
+    #[pg_test]
+    fn test_jsonschema_validation_errors_invalid_schema() {
+        let errors = crate::jsonschema_validation_errors(
+            Json(json!({ "enum": 1 })),
+            Json(json!("anything")),
+        );
+        assert!(!errors.is_empty());
+    }
 
     #[pg_test]
     fn test_json_matches_schema_rs() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,8 @@ fn jsonb_matches_compiled_schema(
     validator.is_valid(&instance.0)
 }
 
-#[pg_extern(
-    immutable,
-    strict,
-    parallel_safe,
-    name = "jsonschema_validation_errors_compiled"
-)]
-fn jsonschema_validation_errors_compiled(
+#[pg_extern(immutable, strict, parallel_safe)]
+fn json_validation_errors_compiled(
     schema: JsonSchema,
     instance: Json,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -99,13 +94,8 @@ fn jsonschema_validation_errors_compiled(
         .collect()
 }
 
-#[pg_extern(
-    immutable,
-    strict,
-    parallel_safe,
-    name = "jsonb_validation_errors_compiled"
-)]
-fn jsonschema_validation_errors_compiled_jsonb(
+#[pg_extern(immutable, strict, parallel_safe)]
+fn jsonb_validation_errors_compiled(
     schema: JsonSchema,
     instance: pgrx::JsonB,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -146,7 +136,7 @@ mod tests {
             #[pg_test]
             fn $name() {
                 let errors = Spi::get_one::<Vec<String>>(concat!(
-                    "SELECT jsonschema_validation_errors_compiled('", $schema, "'::jsonschema, '",
+                    "SELECT json_validation_errors_compiled('", $schema, "'::jsonschema, '",
                     $instance, "'::json)"
                 )).unwrap().unwrap();
                 assert_eq!(errors, [$($err),*]);
@@ -219,7 +209,7 @@ mod tests {
     #[pg_test]
     fn test_validation_errors_compiled_no_errors() {
         let errors = Spi::get_one::<Vec<String>>(
-            r#"SELECT jsonschema_validation_errors_compiled('{"maxLength":4}'::jsonschema, '"foo"'::json)"#,
+            r#"SELECT json_validation_errors_compiled('{"maxLength":4}'::jsonschema, '"foo"'::json)"#,
         )
         .unwrap()
         .unwrap();
@@ -230,7 +220,7 @@ mod tests {
     fn test_validation_errors_compiled_multiple() {
         let errors = Spi::get_one::<Vec<String>>(
             r#"
-            SELECT jsonschema_validation_errors_compiled(
+            SELECT json_validation_errors_compiled(
                 '{
                     "type":"object",
                     "properties":{


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a two-level cache for JSON Schema validators including a few public functions + `jsonschema` cast

## What is the current behavior?

Currently, validators are re-compiled on every call.

## What is the new behavior?

Compiled validators are stored in a per-process LRU cache + per callsite cache

Resolves #88

Some time ago I've read https://www.enterprisedb.com/blog/validating-shape-your-json-data which inspired me to make this PR. Also, it seems like in that comparison they use the debug build :(
